### PR TITLE
Adding KMS topic snippets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,13 @@
 ### Description
 
-Adding command for SNS to enable KMS encryption with the masterKey property
-Adding command for SNS to enable KMS encryption with the masterKey property with kms from arn
+_Write here_
 
 ### Check List
 
-- [sns.code-snippets] Syntax tested
+- [ ] Syntax tested
 - [ ] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section
 
 ### Tested with:
 
-- CDK version: _1.67_
-- VSCode version: _1.49.2_
+- CDK version: _(Write here)_
+- VSCode version: _(Write here)_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,14 @@
 ### Description
 
-_Write here_
+Adding command for SNS to enable KMS encryption with the masterKey property
+Adding command for SNS to enable KMS encryption with the masterKey property with kms from arn
 
 ### Check List
 
-- [ ] Syntax tested
+- [sns.code-snippets] Syntax tested
 - [ ] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section
 
 ### Tested with:
 
-- CDK version: _(Write here)_
-- VSCode version: _(Write here)_
+- CDK version: _1.67_
+- VSCode version: _1.49.2_

--- a/snippets/sns.code-snippets
+++ b/snippets/sns.code-snippets
@@ -8,7 +8,26 @@
     ],
     "description": "Add a SNS topic"
   },
-
+  "TopicWithKms": {
+    "prefix": "sns-topic-encrypted-kms",
+    "body": [
+      "new sns.Topic(this, \"${1:id}\", {",
+      "  topicName: \"${2}\",",
+      "  masterKey: ${3:kmsKey},",
+      "})"
+    ],
+    "description": "Add an encrypted SNS topic with KMS encryption"
+  },
+  "TopicWithKmsFromArn": {
+    "prefix": "sns-topic-encrypted-kms-from-arn",
+    "body": [
+      "new sns.Topic(this, \"${1:id}\", {",
+      "  topicName: \"${2}\",",
+      "  masterKey: kms.Key.fromKeyArn(this, \"${3:id}\", \"arn:aws:kms:${4:region}:${5:accountId}:key/${6:keyId}\")",
+      "})"
+    ],
+    "description": "Add an encrypted SNS topic with an imported KMS key by ARN"
+  },
   "TopicFromArn": {
     "prefix": "sns-topic-from-arn",
     "body": [


### PR DESCRIPTION
### Description

Adding command for SNS to enable KMS encryption with the masterKey property
Adding command for SNS to enable KMS encryption with the masterKey property with kms from arn

### Check List

- [sns.code-snippets] Syntax tested
- [ ] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section

### Tested with:

- CDK version: _1.67_
- VSCode version: _1.49.2_