### PR TITLE
fix: propagate stack props to super

### DIFF
--- a/snippets/core.code-snippets
+++ b/snippets/core.code-snippets
@@ -36,7 +36,7 @@
       "",
       "export class ${1:StackName} extends Stack {",
       "  constructor(scope: App, id: string, props: ${1:StackName}Props) {",
-      "    super(scope, id);",
+      "    super(scope, id, props);",
       "",
       "    ${2}",
       "  }",


### PR DESCRIPTION
### Description

Propagate the stack props to the parent class

### Check List

- [X] Syntax tested
- [ ] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section

### Tested with:

- CDK version: _(Write here)_
- VSCode version: _(Write here)_
