### PR TITLE
ci(conventional-commit-check): Add Github action to check PRs title

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,22 @@
+name: Pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v2.2.2
+        with:
+          success-state: ✅  PR title follows conventional commit specifications
+          failure-state: ❌  PR title doesn't follow conventional commit specifications
+          context-name: conventional-pr-title
+          preset: conventional-changelog-angular@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Add conventional commit specification check for PR title.
PR title is used during merge as the title for the squash & merge strategy

### Check List

- [ ] Syntax tested
- [ ] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section

### Tested with:

- CDK version: _(Write here)_
- VSCode version: _(Write here)_
