### PR TITLE
fix(core): Updated to v2 syntax

### DIFF
--- a/snippets/core.code-snippets
+++ b/snippets/core.code-snippets
@@ -1,21 +1,21 @@
 {
   "CDK Import": {
     "prefix": "cdk-import",
-    "body": ["import * as ${1:service} from '@aws-cdk/aws-${1:service}';"],
+    "body": ["import * as ${1:service} from 'aws-cdk-lib/aws-${1:service}';"],
     "description": "Generate a CDK import statement"
   },
 
   "CDK Construct": {
     "prefix": "cdk-construct",
     "body": [
-      "import * as cdk from '@aws-cdk/core';",
+      "import { Construct } from 'constructs';",
       "",
       "export interface ${1:ConstructorName}Props {",
       "",
       "}",
       "",
-      "export class ${1:ConstructorName} extends cdk.Construct {",
-      "  constructor(scope: cdk.Construct, id: string, props: ${1:ConstructorName}Props) {",
+      "export class ${1:ConstructorName} extends Construct {",
+      "  constructor(scope: Construct, id: string, props: ${1:ConstructorName}Props) {",
       "    super(scope, id);",
       "",
       "    ${3}",
@@ -28,14 +28,15 @@
   "CDK Stack": {
     "prefix": "cdk-stack",
     "body": [
-      "import * as cdk from '@aws-cdk/core';",
+      "import { Stack, StackProps } from 'aws-cdk-lib';",
+      "import { Construct } from 'constructs';",
       "",
-      "export interface ${1:StackName}Props extends cdk.StackProps {",
+      "export interface ${1:StackName}Props extends StackProps {",
       "",
       "}",
       "",
-      "export class ${1:StackName} extends cdk.Stack {",
-      "  constructor(scope: cdk.Construct, id: string, props: ${1:StackName}Props) {",
+      "export class ${1:StackName} extends Stack {",
+      "  constructor(scope: Construct, id: string, props: ${1:StackName}Props) {",
       "    super(scope, id, props);",
       "",
       "    ${2}",
@@ -50,7 +51,7 @@
     "body": [
       "#!/usr/bin/env node",
       "import 'source-map-support/register';",
-      "import * as cdk from '@aws-cdk/core';",
+      "import * as cdk from 'aws-cdk-lib';",
       "",
       "const app = new cdk.App();",
       "",


### PR DESCRIPTION
### Description

Updated core snippets to CDK v2 syntax (imports from 'aws-cdk-lib' instead of @aws-cdk)
Related to Issue #16 

### Check List

- [x] Syntax tested
- [x] In case of new snippet file, the respective entry has been added to _package.json_ _contributes_ section

### Tested with:

- CDK version: 2.41.0
- VSCode version: 1.71.1
